### PR TITLE
style update on upload button for better visibility

### DIFF
--- a/src/components/Fileuploader.jsx
+++ b/src/components/Fileuploader.jsx
@@ -44,12 +44,21 @@ export default function FileUploader({ onExtract, onRemove }) {
       </div>
 
       {!isUploaded && (
-        <input
-          type="file"
-          accept="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/csv,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-          onChange={handleFileChange}
-          className="mb-2 mt-2"
-        />
+        <div className="mt-2">
+          <label
+            htmlFor="file-upload"
+            className="cursor-pointer bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          >
+            Browse...
+          </label>
+          <input
+            id="file-upload"
+            type="file"
+            accept="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/csv,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            onChange={handleFileChange}
+            className="hidden"
+          />
+        </div>
       )}
 
       {isUploaded && (


### PR DESCRIPTION
PR addresses a ux issue where the file upload input in the Fileuploader component was unstyled (Mozilla Firefox, Arch Linux 6.15.4), and hence me along with a couple others could not find how to upload the actual file. The new "Browse..." button is now clear and styled using tailwind and the input is wrapped in a label for accessibility.

Before:
<img width="535" height="196" alt="image" src="https://github.com/user-attachments/assets/531a126a-7b7d-4a59-a892-df41d4b634d6" />

After:
<img width="535" height="196" alt="image" src="https://github.com/user-attachments/assets/bda2243f-6f01-4bb6-9be0-d36d7f9cf953" />
